### PR TITLE
use peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/orgsync/react-list"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.12.0"
   }
 }


### PR DESCRIPTION
Avoid duplicate version of dependencies and rely on the parent React instance.