### PR TITLE
added bower dev dependency since the Makefile requires it

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "0.13.x"
   },
   "devDependencies": {
+    "bower": "1.4.1",
     "cogs": "1.0.4",
     "cogs-transformer-babel": "1.0.10"
   }


### PR DESCRIPTION
The build fails if you don't have bower installed globally with npm. This fixes that.