### PR TITLE
Round the spacing up to set of items

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -209,7 +209,7 @@ export class UniformList extends List {
   }
 
   getSpace(n) {
-    return (n / this.state.itemsPerRow) * this.state.itemHeight;
+    return Math.ceil(n / this.state.itemsPerRow) * this.state.itemHeight;
   }
 
   render() {


### PR DESCRIPTION
When you make a call to `getSpace` in `render`, it is called with the current length. This is buggy when the length doesn’t fit into the number of items per row. For example, I have 50 items and 6 columns, “50 / 6 === 8.3333” but in reality I have nine uniform rows.