### PR TITLE
use pageSize prop instead of the constant 1

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -141,9 +141,9 @@ export class UniformList extends List {
 
   componentWillReceiveProps(next) {
     let {itemsPerRow, from, size} = this.state;
-    const {length} = next;
+    const {length, pageSize} = next;
     from = Math.max(Math.min(from, this.getMaxFrom(length, itemsPerRow)), 0);
-    size = Math.min(Math.max(size, 1), length - from);
+    size = Math.min(Math.max(size, pageSize), length - from);
     this.setState({from, size});
   }
 


### PR DESCRIPTION
#18 worked for server rendered pages but failed if the component was rendered in the client, showing only 1 item again. This fixes that.