### PR TITLE
Support react 0.14 prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/orgsync/react-list"
   },
   "peerDependencies": {
-    "react": ">= 0.13.0 < 0.15.0"
+    "react": ">= 0.13.0 < 0.15.0 || ^0.14.0-alpha"
   },
   "devDependencies": {
     "bower": "1.4.1",


### PR DESCRIPTION
This fix will let you use any of the react 0.14 betas and react 0.14.0-rc1.
Semver won't allow prereleases by default. 