### PR TITLE
Adding support for 'overflow: overlay'.

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -99,7 +99,7 @@ export default class extends React.Component {
     const overflowKey = OVERFLOW_KEYS[this.props.axis];
     while (el = el.parentElement) {
       const overflow = window.getComputedStyle(el)[overflowKey];
-      if (overflow === 'auto' || overflow === 'scroll') return el;
+      if (overflow === 'auto' || overflow === 'scroll' || overflow === 'overlay') return el;
     }
     return window;
   }

--- a/react-list.js
+++ b/react-list.js
@@ -166,7 +166,7 @@
         var overflowKey = OVERFLOW_KEYS[this.props.axis];
         while (el = el.parentElement) {
           var overflow = window.getComputedStyle(el)[overflowKey];
-          if (overflow === 'auto' || overflow === 'scroll') return el;
+          if (overflow === 'auto' || overflow === 'scroll' || overflow === 'overlay') return el;
         }
         return window;
       }


### PR DESCRIPTION
We discovered that the list would not scroll if it was set to "overflow: overlay". This adds support for this (deprecated but useful) feature.