### PR TITLE
Fix React 0.14 support when using webpack

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -7,11 +7,17 @@ const isEqualSubset = (a, b) => {
 
 const isEqual = (a, b) => isEqualSubset(a, b) && isEqualSubset(b, a);
 
-const {findDOMNode} =
-  React.version < '0.14.0' ? React :
-  typeof window === 'object' && window.ReactDOM ? window.ReactDOM :
-  typeof require === 'function' ? eval('require')('react-dom') :
-  React;
+let ReactDOM;
+if (React.version < '0.14.0') {
+  ReactDOM = React;
+} else {
+  try {
+    ReactDOM = require('react-dom');
+  } catch(e) {
+    ReactDOM = React;
+  }
+}
+const {findDOMNode} = ReactDOM;
 
 const CLIENT_START_KEYS = {x: 'clientTop', y: 'clientLeft'};
 const CLIENT_SIZE_KEYS = {x: 'clientWidth', y: 'clientHeight'};


### PR DESCRIPTION
This is the best I can do - this leads to a warning at build time (but not an error, because of the `try`/`catch`) when using React 0.13 and webpack, but no other problems there as far as I can tell.