### PR TITLE
Cancel animation frame on componentWillUnmount only if this.afId is set

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -88,7 +88,9 @@ export default class extends Component {
   componentWillUnmount() {
     window.removeEventListener('resize', this.updateFrame);
     this.scrollParent.removeEventListener('scroll', this.updateFrame);
-    cancelAnimationFrame(this.afId);
+    if (this.afId) {
+      cancelAnimationFrame(this.afId);
+    }
   }
 
   getOffset(el) {

--- a/react-list.js
+++ b/react-list.js
@@ -157,7 +157,9 @@
       value: function componentWillUnmount() {
         window.removeEventListener('resize', this.updateFrame);
         this.scrollParent.removeEventListener('scroll', this.updateFrame);
-        cancelAnimationFrame(this.afId);
+        if (this.afId) {
+          cancelAnimationFrame(this.afId);
+        }
       }
     }, {
       key: 'getOffset',


### PR DESCRIPTION
Fixes unmounting. Currently generates an error because cancelAnimationFrame is being called with undefined value - this.afId is set only when initialIndex property is given. 