### PR TITLE
Use `itemSizeGetter` if provided

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -153,15 +153,22 @@ export default class extends Component {
 
     const firstEl = itemEls[0];
 
-    // Firefox has a problem where it will return a *slightly* (less than
-    // thousandths of a pixel) different size for the same element between
-    // renders. This can cause an infinite render loop, so only change the
-    // itemSize when it is significantly different.
-    let {itemSize} = this.state;
-    const {axis} = this.props;
-    const firstElSize = firstEl[OFFSET_SIZE_KEYS[axis]];
-    const delta = Math.abs(firstElSize - itemSize);
-    if (isNaN(delta) || delta >= 1) itemSize = firstElSize;
+    let itemSize;
+    
+    if( this.props.itemSizeGetter ) {
+      itemSize = this.props.itemSizeGetter(0);
+    }
+    else {
+      // Firefox has a problem where it will return a *slightly* (less than
+      // thousandths of a pixel) different size for the same element between
+      // renders. This can cause an infinite render loop, so only change the
+      // itemSize when it is significantly different.
+      itemSize = this.state.itemSize;
+      const {axis} = this.props;
+      const firstElSize = firstEl[OFFSET_SIZE_KEYS[axis]];
+      const delta = Math.abs(firstElSize - itemSize);
+      if (isNaN(delta) || delta >= 1) itemSize = firstElSize;
+    }
 
     if (!itemSize) return {};
 


### PR DESCRIPTION
This pull request makes it so that `itemSizeGetter` is used even if the `type` is `uniform`.

If no `itemSizeGetter` is provided it falls back to (the original method of) reading `firstEl[OFFSET_SIZE_KEYS[axis]]`.

This is not just a (minor) performance boost, but actually fixes a bug: margin's are not taken into account when determining an item's size.

Other options to fix this include:
1) Getting the element's margin's from `getComputedStyle` and adding it on
2) Asking for the margin's to passed in as a prop

This method seemed easiest and made use of an existing prop that was ignored unexpectedly.