### PR TITLE
Prevent crash on early unmount.

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -86,7 +86,7 @@ export default class extends Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.updateFrame);
-    this.scrollParent.removeEventListener('scroll', this.updateFrame);
+    this.scrollParent && this.scrollParent.removeEventListener('scroll', this.updateFrame);
   }
 
   getOffset(el) {
@@ -177,6 +177,9 @@ export default class extends Component {
   }
 
   updateFrame(cb) {
+    // We may have been unmounted on the 'resize' event. If so, this function will
+    // error so we skip the processing.
+    if (this.render) return;
     this.updateScrollParent();
     if (typeof cb != 'function') cb = NOOP;
     switch (this.props.type) {


### PR DESCRIPTION
Issue is with a parent that responds to resizing
and dismounts the component before componentWillUnmount fires,
causing the DOM access to fail and throw an invariant.

Dismounting before componentWillUnmount shouldn't be
possible, but here we are.

Some context: my main component has several different layouts that are triggered by standard responsive breakpoints. I listen to `'resize'` in order to swap them out. 

It appears that the 'resize' listeners in react-list fire several times on a resize (since that event fires so quickly) and during that time, a dismount occurs *before* componentWillUnmount. Sounds strange, I know. If needed I can work up a small POC.

The check in `findDOMNode` [checks for the existence of `render`](https://github.com/facebook/react/blob/master/src/renderers/dom/client/findDOMNode.js#L57) to figure out if the component is mounted or not. Apparently, the `render` function is removed while a component is mounted (TIL). We can use that same check to prevent the error.