### PR TITLE
Fix off-by-one error when itemsPerRow > 1

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -275,7 +275,7 @@ export default class extends Component {
     // Try the static itemSize.
     const {itemSize, itemsPerRow} = this.state;
     if (itemSize) {
-      return cache[index] = Math.ceil(index / itemsPerRow) * itemSize;
+      return cache[index] = Math.floor(index / itemsPerRow) * itemSize;
     }
 
     // Find the closest space to index there is a cached value for.


### PR DESCRIPTION
Found this bug through scrollTo jumping to the wrong space.

This fragment calculates the row index given the list index and itemsPerRow:
`Math.ceil(index / itemsPerRow)`
When itemsPerRow is 2 and index is 1, expected row index is 0, but actual is 1.