### PR TITLE
Compatible scrollWidth, scrollHeight for Firefox and IE

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -147,7 +147,7 @@ export default class extends Component {
     const {scrollParent} = this;
     const {axis} = this.props;
     return scrollParent === window ?
-      document.body[SCROLL_SIZE_KEYS[axis]] :
+      Math.max(document.body[SCROLL_SIZE_KEYS[axis]], document.documentElement[SCROLL_SIZE_KEYS[axis]]) :
       scrollParent[SCROLL_SIZE_KEYS[axis]];
   }
 

--- a/react-list.js
+++ b/react-list.js
@@ -228,7 +228,7 @@
         var scrollParent = this.scrollParent;
         var axis = this.props.axis;
 
-        return scrollParent === window ? document.body[SCROLL_SIZE_KEYS[axis]] : scrollParent[SCROLL_SIZE_KEYS[axis]];
+        return scrollParent === window ? Math.max(document.body[SCROLL_SIZE_KEYS[axis]], document.documentElement[SCROLL_SIZE_KEYS[axis]]) : scrollParent[SCROLL_SIZE_KEYS[axis]];
       }
     }, {
       key: 'hasDeterminateSize',


### PR DESCRIPTION
### Problem
List does not updates when scrolling with Firefox (tested version > 44.0) and IE (tested version > 11)

### Analysis
Firefox always returns same document.body.scroll(Width | Height) even if scrolling size changes.
document.documentElement.scroll(Width | Height) returns correct size.

### Fix
Use Math.max of two variables in body or documentElement