### PR TITLE
Optimize scroll performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "peerDependencies": {
     "react": "0.14 || >= 15.0.0-rc.1 < 16",
-    "react-dom": "0.14 || >= 15.0.0-rc.1 < 16"
+    "react-dom": "0.14 || >= 15.0.0-rc.1 < 16",
+    "react-addons-shallow-compare": "0.14 || >= 15.0.0-rc.1 < 16"
   },
   "devDependencies": {
     "cogs": "1.0.7",

--- a/react-list.es6
+++ b/react-list.es6
@@ -1,14 +1,8 @@
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
+import shallowCompare from 'react-addons-shallow-compare';
 
 const {findDOMNode} = ReactDOM;
-
-const isEqualSubset = (a, b) => {
-  for (let key in a) if (a[key] !== b[key]) return false;
-  return true;
-};
-
-const isEqual = (a, b) => isEqualSubset(a, b) && isEqualSubset(b, a);
 
 const CLIENT_SIZE_KEYS = {x: 'clientWidth', y: 'clientHeight'};
 const CLIENT_START_KEYS = {x: 'clientTop', y: 'clientLeft'};
@@ -75,7 +69,7 @@ export default class extends Component {
   }
 
   shouldComponentUpdate(props, state) {
-    return !isEqual(props, this.props) || !isEqual(state, this.state);
+    return shallowCompare(this, props, state);
   }
 
   componentDidUpdate() {

--- a/react-list.es6
+++ b/react-list.es6
@@ -70,7 +70,7 @@ export default class extends Component {
 
   componentDidMount() {
     this.updateFrame = this.updateFrame.bind(this);
-    window.addEventListener('resize', this.updateFrame);
+    window.addEventListener('resize', this.updateFrame, {passive: true});
     this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
   }
 
@@ -219,7 +219,7 @@ export default class extends Component {
       prev.removeEventListener('scroll', this.updateFrame);
       prev.removeEventListener('mousewheel', NOOP);
     }
-    this.scrollParent.addEventListener('scroll', this.updateFrame);
+    this.scrollParent.addEventListener('scroll', this.updateFrame, {passive: true});
     this.scrollParent.addEventListener('mousewheel', NOOP);
   }
 

--- a/react-list.js
+++ b/react-list.js
@@ -137,7 +137,7 @@
       key: 'componentDidMount',
       value: function componentDidMount() {
         this.updateFrame = this.updateFrame.bind(this);
-        window.addEventListener('resize', this.updateFrame);
+        window.addEventListener('resize', this.updateFrame, { passive: true });
         this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
       }
     }, {
@@ -314,7 +314,7 @@
           prev.removeEventListener('scroll', this.updateFrame);
           prev.removeEventListener('mousewheel', NOOP);
         }
-        this.scrollParent.addEventListener('scroll', this.updateFrame);
+        this.scrollParent.addEventListener('scroll', this.updateFrame, { passive: true });
         this.scrollParent.addEventListener('mousewheel', NOOP);
       }
     }, {

--- a/react-list.js
+++ b/react-list.js
@@ -1,16 +1,16 @@
 (function (global, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['exports', 'module', 'react', 'react-dom'], factory);
+    define(['exports', 'module', 'react', 'react-dom', 'react-addons-shallow-compare'], factory);
   } else if (typeof exports !== 'undefined' && typeof module !== 'undefined') {
-    factory(exports, module, require('react'), require('react-dom'));
+    factory(exports, module, require('react'), require('react-dom'), require('react-addons-shallow-compare'));
   } else {
     var mod = {
       exports: {}
     };
-    factory(mod.exports, mod, global.React, global.ReactDOM);
+    factory(mod.exports, mod, global.React, global.ReactDOM, global.shallowCompare);
     global.ReactList = mod.exports;
   }
-})(this, function (exports, module, _react, _reactDom) {
+})(this, function (exports, module, _react, _reactDom, _reactAddonsShallowCompare) {
   'use strict';
 
   var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
@@ -27,17 +27,9 @@
 
   var _ReactDOM = _interopRequireDefault(_reactDom);
 
+  var _shallowCompare = _interopRequireDefault(_reactAddonsShallowCompare);
+
   var findDOMNode = _ReactDOM['default'].findDOMNode;
-
-  var isEqualSubset = function isEqualSubset(a, b) {
-    for (var key in a) {
-      if (a[key] !== b[key]) return false;
-    }return true;
-  };
-
-  var isEqual = function isEqual(a, b) {
-    return isEqualSubset(a, b) && isEqualSubset(b, a);
-  };
 
   var CLIENT_SIZE_KEYS = { x: 'clientWidth', y: 'clientHeight' };
   var CLIENT_START_KEYS = { x: 'clientTop', y: 'clientLeft' };
@@ -143,7 +135,7 @@
     }, {
       key: 'shouldComponentUpdate',
       value: function shouldComponentUpdate(props, state) {
-        return !isEqual(props, this.props) || !isEqual(state, this.state);
+        return (0, _shallowCompare['default'])(this, props, state);
       }
     }, {
       key: 'componentDidUpdate',


### PR DESCRIPTION
Hi, I'm using this package in my Twitter client application.  I found that scroll performance of timeline is not so good.  So I added some rendering optimizations to this package.

Now scrolling performance is 10% faster in average.  And it's especially effective when re-rendering happens so many times.

1. I used [passive DOM event](https://developer.mozilla.org/ja/docs/Web/API/EventTarget/addEventListener) because `this.updateFrame` doesn't prevent browser's event handling by `preventDefault` or `stopPropagation`.  This is available in the latest browsers and old ones simply ignore this.  So there is no breaking change.
2. Use React's official [shallow compare](https://facebook.github.io/react/docs/shallow-compare.html) addon.
3. Use `requestAnimationFrame` not to prevent scrolling animation.  This has most impact to performance in this PR.  For example, in my app, `j` scrolls down a timeline.  When key-repeating `j`, there was so many `setState` call and re-rendering. As the result, app couldn't accept user's input any more until all input were processed.  After using animation frame to render, rendering is performed once per animation frame, avoiding boring so many re-renderings by `setState`.
