### PR TITLE
Add ESLint.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,40 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
+    }
+  },
+  "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "env": {
+    "es6": true,
+    "node": true,
+    "browser": true
+  },
+  "rules": {
+
+    "eqeqeq": [2, "smart"],
+    "linebreak-style": [2, "unix"],
+    "prefer-arrow-callback": 2,
+    "quotes": [2, "single", "avoid-escape"],
+    "semi": [2, "always"],
+    "strict": [2, "never"],
+    "yoda": [2, "never"],
+
+    "no-alert": 2,
+    "no-console": 2,
+    "no-cond-assign": 0,
+    "no-const-assign": 2,
+    "no-else-return": 2,
+    "no-this-before-super": 2,
+    "no-unexpected-multiline": 2,
+    "no-var": 2,
+    "no-warning-comments": 1
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,5 @@ COGS=$(BIN)cogs
 
 dev:
 	npm install
+	npm run lint
 	$(COGS) -w examples/index.es6,react-list.es6

--- a/examples/index.es6
+++ b/examples/index.es6
@@ -123,7 +123,7 @@ const examples = [
   }
 ];
 
-export default class extends React.Component {
+export default class ExampleClass extends React.Component {
   renderExamples() {
     return examples.map((props, key) =>
       <div key={key} className={`example axis-${props.axis}`}>

--- a/package.json
+++ b/package.json
@@ -8,17 +8,23 @@
     "type": "git",
     "url": "https://github.com/orgsync/react-list"
   },
+  "scripts": {
+    "lint": "eslint --ext .es6 ."
+  },
   "peerDependencies": {
     "react": "0.14 || 15",
     "react-dom": "0.14 || 15"
   },
   "devDependencies": {
+    "babel-eslint": "^6.1.2",
+    "babel-plugin-transform-es2015-modules-umd": "6.12.0",
     "babel-preset-es2015": "6.13.2",
     "babel-preset-react": "6.11.1",
     "babel-preset-stage-0": "6.5.0",
-    "babel-plugin-transform-es2015-modules-umd": "6.12.0",
     "cogs": "2.0.9",
     "cogs-transformer-babel": "2.0.4",
-    "cogs-transformer-replace": "1.0.1"
+    "cogs-transformer-replace": "1.0.1",
+    "eslint": "^3.3.1",
+    "eslint-plugin-react": "^6.1.2"
   }
 }

--- a/react-list.es6
+++ b/react-list.es6
@@ -36,7 +36,7 @@ const PASSIVE = (() => {
         return false;
       }
     });
-  } catch (e) {}
+  } catch (e) {/* ignore */}
   return hasSupport;
 })() ? {passive: true} : false;
 
@@ -450,4 +450,4 @@ module.exports = class ReactList extends Component {
     };
     return <div {...{style}}><div style={listStyle}>{items}</div></div>;
   }
-}
+};


### PR DESCRIPTION
A local .eslintrc is required in at least Sublime Text in order to get past the ES6 syntax. The eslintrc is copied from a few projects I do - it's decently strict (even on a few React things) but didn't require any significant code changes.