### PR TITLE
Prevent possible infinite loop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,15 +171,6 @@ viewport.
 
 ## FAQ
 
-##### Why is the list freezing/overflowing the stack?
-
-This happens when specifying the `uniform` type without actually providing
-uniform size elements. The component attempts to draw only the minimum necessary
-elements at one time and that minimum element calculation is based off the first
-element in the list. When the first element does not match the other elements,
-the calculation will be wrong and the component will never be able to fully
-resolve the ideal necessary elements.
-
 ##### Why doesn't it work with margins?
 
 The calculations to figure out element positioning and size get significantly
@@ -189,7 +180,7 @@ spacing.
 
 ##### Why is there no onScroll event handler?
 
-If you need an onScroll handler, just add the handler to the div wrapping your ReactList component: 
+If you need an onScroll handler, just add the handler to the div wrapping your ReactList component:
 
 ```
 <div style={{height: 300, overflow: 'auto'}} onScroll={this.handleScroll}>

--- a/react-list.es6
+++ b/react-list.es6
@@ -33,6 +33,15 @@ const PASSIVE = (() => {
   return hasSupport;
 })() ? {passive: true} : false;
 
+const isEqualSubset = (a, b) => {
+  if (!a || !b) return false;
+  for (let key in b) if (a[key] !== b[key]) return false;
+
+  return true;
+};
+
+const isEqual = (a, b) => isEqualSubset(a, b) && isEqualSubset(b, a);
+
 module.exports = class ReactList extends Component {
   static displayName = 'ReactList';
 
@@ -72,6 +81,7 @@ module.exports = class ReactList extends Component {
       this.constrain(initialIndex, pageSize, itemsPerRow, this.props);
     this.state = {from, size, itemsPerRow};
     this.cache = {};
+    this.updateCounter = 0;
   }
 
   componentWillReceiveProps(next) {
@@ -85,15 +95,25 @@ module.exports = class ReactList extends Component {
     this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
   }
 
-  componentDidUpdate() {
-    this.updateFrame();
+  componentDidUpdate(prevProps, prevState) {
+    // If the parent has changed any props, we want to update.
+    if (!isEqual(this.props, prevProps)) return this.updateFrame();
+    // If size has changed, we also want to update. This is important
+    // to ensure that lists fully fill, no matter the `pageSize`.
+    if (this.state.size !== prevState.size) {
+      // Size is unstable; we've done too many renders in a row.
+      if (++this.updateCounter > 100) return;
+      // This can cascade, so we want to keep it from possibly
+      // blowing the stack.
+      return setTimeout(() => this.updateFrame(), 0);
+    }
+    this.updateCounter = 0;
   }
 
-  maybeSetState(b, cb) {
-    const a = this.state;
-    for (let key in b) if (a[key] !== b[key]) return this.setState(b, cb);
+  maybeSetState(newState, cb) {
+    if (isEqualSubset(this.state, newState)) return cb();
 
-    cb();
+    this.setState(newState, cb);
   }
 
   componentWillUnmount() {
@@ -303,7 +323,7 @@ module.exports = class ReactList extends Component {
       this.props
     );
 
-    return this.maybeSetState({itemsPerRow, from, itemSize, size}, cb);
+    this.maybeSetState({itemsPerRow, from, itemSize, size}, cb);
   }
 
   getSpaceBefore(index, cache = {}) {

--- a/react-list.es6
+++ b/react-list.es6
@@ -90,6 +90,7 @@ module.exports = class ReactList extends Component {
   }
 
   componentDidMount() {
+    this.mounted = true;
     this.updateFrame = this.updateFrame.bind(this);
     window.addEventListener('resize', this.updateFrame);
     this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
@@ -117,6 +118,7 @@ module.exports = class ReactList extends Component {
   }
 
   componentWillUnmount() {
+    this.mounted = false;
     window.removeEventListener('resize', this.updateFrame);
     this.scrollParent.removeEventListener('scroll', this.updateFrame, PASSIVE);
     this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
@@ -236,6 +238,7 @@ module.exports = class ReactList extends Component {
   }
 
   updateFrame(cb) {
+    if (!this.mounted) return;
     this.updateScrollParent();
     if (typeof cb != 'function') cb = NOOP;
     switch (this.props.type) {

--- a/react-list.js
+++ b/react-list.js
@@ -107,6 +107,17 @@
     return hasSupport;
   }() ? { passive: true } : false;
 
+  var isEqualSubset = function isEqualSubset(a, b) {
+    if (!a || !b) return false;
+    for (var key in b) {
+      if (a[key] !== b[key]) return false;
+    }return true;
+  };
+
+  var isEqual = function isEqual(a, b) {
+    return isEqualSubset(a, b) && isEqualSubset(b, a);
+  };
+
   _module3.default.exports = (_temp = _class = function (_Component) {
     _inherits(ReactList, _Component);
 
@@ -127,6 +138,7 @@
 
       _this.state = { from: from, size: size, itemsPerRow: itemsPerRow };
       _this.cache = {};
+      _this.updateCounter = 0;
       return _this;
     }
 
@@ -149,16 +161,30 @@
       }
     }, {
       key: 'componentDidUpdate',
-      value: function componentDidUpdate() {
-        this.updateFrame();
+      value: function componentDidUpdate(prevProps, prevState) {
+        var _this2 = this;
+
+        // If the parent has changed any props, we want to update.
+        if (!isEqual(this.props, prevProps)) return this.updateFrame();
+        // If size has changed, we also want to update. This is important
+        // to ensure that lists fully fill, no matter the `pageSize`.
+        if (this.state.size !== prevState.size) {
+          // Size is unstable; we've done too many renders in a row.
+          if (++this.updateCounter > 100) return;
+          // This can cascade, so we want to keep it from possibly
+          // blowing the stack.
+          return setTimeout(function () {
+            return _this2.updateFrame();
+          }, 0);
+        }
+        this.updateCounter = 0;
       }
     }, {
       key: 'maybeSetState',
-      value: function maybeSetState(b, cb) {
-        var a = this.state;
-        for (var key in b) {
-          if (a[key] !== b[key]) return this.setState(b, cb);
-        }cb();
+      value: function maybeSetState(newState, cb) {
+        if (isEqualSubset(this.state, newState)) return cb();
+
+        this.setState(newState, cb);
       }
     }, {
       key: 'componentWillUnmount',
@@ -412,7 +438,7 @@
             from = _constrain.from,
             size = _constrain.size;
 
-        return this.maybeSetState({ itemsPerRow: itemsPerRow, from: from, itemSize: itemSize, size: size }, cb);
+        this.maybeSetState({ itemsPerRow: itemsPerRow, from: from, itemSize: itemSize, size: size }, cb);
       }
     }, {
       key: 'getSpaceBefore',
@@ -552,7 +578,7 @@
     }, {
       key: 'renderItems',
       value: function renderItems() {
-        var _this2 = this;
+        var _this3 = this;
 
         var _props7 = this.props,
             itemRenderer = _props7.itemRenderer,
@@ -565,7 +591,7 @@
         for (var i = 0; i < size; ++i) {
           items.push(itemRenderer(from + i, i));
         }return itemsRenderer(items, function (c) {
-          return _this2.items = c;
+          return _this3.items = c;
         });
       }
     }, {

--- a/react-list.js
+++ b/react-list.js
@@ -155,6 +155,7 @@
     }, {
       key: 'componentDidMount',
       value: function componentDidMount() {
+        this.mounted = true;
         this.updateFrame = this.updateFrame.bind(this);
         window.addEventListener('resize', this.updateFrame);
         this.updateFrame(this.scrollTo.bind(this, this.props.initialIndex));
@@ -189,6 +190,7 @@
     }, {
       key: 'componentWillUnmount',
       value: function componentWillUnmount() {
+        this.mounted = false;
         window.removeEventListener('resize', this.updateFrame);
         this.scrollParent.removeEventListener('scroll', this.updateFrame, PASSIVE);
         this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
@@ -332,6 +334,7 @@
     }, {
       key: 'updateFrame',
       value: function updateFrame(cb) {
+        if (!this.mounted) return;
         this.updateScrollParent();
         if (typeof cb != 'function') cb = NOOP;
         switch (this.props.type) {


### PR DESCRIPTION
updateFrame() can potentially call setState, causing
componentDidUpdate() to fire again, calling updateFrame(),
which can call setState() yet again and blow the stack.

We instead only updateFrame() after an update if props have
changed, and one additional time at boot to fill out
the container after mount.

I can confirm by testing with `'uniform'` that irregularly-sized items
no longer blow the stack with this patch.

I am not sure if this will have unintended effects but in my limited
testing and in a real-world app, it made no visible change.

Most of the diff in `react-list.js` is from the devDeps upgrade,
as some of the Babel output changed in style.