### PR TITLE
Update keys to match row indices

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -441,7 +441,9 @@ module.exports = class ReactList extends Component {
     const {itemRenderer, itemsRenderer} = this.props;
     const {from, size} = this.state;
     const items = [];
-    for (let i = 0; i < size; ++i) items.push(itemRenderer(from + i, i));
+    for (let i = from, n = from + size; i < n; ++i) {
+      items.push(itemRenderer(i, i));
+    }
     return itemsRenderer(items, c => this.items = c);
   }
 

--- a/react-list.js
+++ b/react-list.js
@@ -590,9 +590,10 @@
             size = _state6.size;
 
         var items = [];
-        for (var i = 0; i < size; ++i) {
-          items.push(itemRenderer(from + i, i));
-        }return itemsRenderer(items, function (c) {
+        for (var i = from, n = from + size; i < n; ++i) {
+          items.push(itemRenderer(i, i));
+        }
+        return itemsRenderer(items, function (c) {
           return _this3.items = c;
         });
       }


### PR DESCRIPTION
Improves performance and fixes Android bug by preventing unnecessary
unmounting and remounting of rows during scrolling.

When the visible region changes during scrolling, the visible rows are
re-rendered with different keys due to the line:

```
for (let i = 0; i < size; ++i) items.push(itemRenderer(from + i, i));
```
https://github.com/orgsync/react-list/blob/master/react-list.es6#L444

For example, the second row will render with `key={1}`.  After scrolling
so the first row is no longer visible, the second row will rerender with
`key={0}`.  This forces React to unmount and remount the row even though
the content has not changed.

This causes two problems:

1. On Chrome Android, when scrolling, if the target node of the touch
   event disappears, the touch events stop firing.  In practice, this
   means you cannot scroll more than a few pixels on Android before
   scrolling stops/breaks since the DOM node is replaced with a new one
   as soon as react-list rerenders.

2. Unmounting and remounting unnecessarily incurs a large performance
   penalty when the rows have significant content in them (e.g. other
   react components that do things when mounted/unmounted). With this
   fix, the list I'm building runs significantly faster and smoother!

Further notes on the Android bug:
 - The react-list examples contain rows with only text, which seem to
   work fine on Chrome, but as soon as you add any child `<div>`s, this
   bug appears.
 - This bug is also reproducible if you use desktop Chrome and enable
   simulating touch events using the developer tools.